### PR TITLE
feat: add GitHub Actions workflow for npm publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: publish
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - name: Verify release tag
+        env:
+          RELEASE_TAG: ${{github.event.release.tag_name}}
+        run: |
+          package_version=$(node --print "require('./package.json').version")
+          if [ "$RELEASE_TAG" != "v$package_version" ]; then
+            echo "Release tag $RELEASE_TAG does not match package version v$package_version"
+            exit 1
+          fi
+      - run: npm ci
+      - run: npm test
+      - run: npm publish --access public

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "markdown",
     "unified"
   ],
-  "repository": "duz52/micromark-extension-math-extended",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/duz52/micromark-extension-math-extended.git"
+  },
   "bugs": "https://github.com/duz52/micromark-extension-math-extended/issues",
   "funding": "https://buymeacoffee.com/duz52",
   "author": "Jerry Ho <jerrynh770@gmail.com> (https://angelrose.org)",


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow for automated npm publishing and updates the repository field in `package.json` to use the expanded object format. These changes improve the release process and package metadata.

**Continuous Integration and Deployment:**

* Added `.github/workflows/publish.yml` to automate npm publishing on new GitHub releases, including version verification, testing, and publishing steps.

**Package Metadata Improvements:**

* Updated the `repository` field in `package.json` to use the expanded object format with `type` and `url`, improving compatibility with npm and related tooling.