### PR TITLE
Ci/npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: publish
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - name: Verify release tag
+        env:
+          RELEASE_TAG: ${{github.event.release.tag_name}}
+        run: |
+          package_version=$(node --print "require('./package.json').version")
+          if [ "$RELEASE_TAG" != "v$package_version" ]; then
+            echo "Release tag $RELEASE_TAG does not match package version v$package_version"
+            exit 1
+          fi
+      - run: npm ci
+      - run: npm test
+      - run: npm publish --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,6 @@ jobs:
             echo "Release tag $RELEASE_TAG does not match package version v$package_version"
             exit 1
           fi
-      - run: npm ci
+      - run: npm install
       - run: npm test
       - run: npm publish --access public

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "markdown",
     "unified"
   ],
-  "repository": "duz52/micromark-extension-math-extended",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/duz52/micromark-extension-math-extended.git"
+  },
   "bugs": "https://github.com/duz52/micromark-extension-math-extended/issues",
   "funding": "https://buymeacoffee.com/duz52",
   "author": "Jerry Ho <jerrynh770@gmail.com> (https://angelrose.org)",


### PR DESCRIPTION
This pull request introduces automated publishing and improves repository metadata. The main changes are the addition of a GitHub Actions workflow for publishing to npm and an update to the repository field in `package.json` for better compatibility with npm and GitHub.

**Automated publishing:**

* Added a new GitHub Actions workflow (`.github/workflows/publish.yml`) that triggers on release publication, verifies the release tag matches the `package.json` version, runs tests, and publishes the package to npm.

**Repository metadata:**

* Updated the `repository` field in `package.json` to use an object with `type` and `url`, improving integration with npm and GitHub.